### PR TITLE
Sets autoDeploy to false

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -8,6 +8,7 @@ services:
   env: docker
   dockerfilePath: ./minio/Dockerfile
   dockerContext: ./minio
+  autoDeploy: false
   disk:
     name: data
     mountPath: /data
@@ -23,6 +24,7 @@ services:
   plan: starter
   dockerfilePath: ./app/Dockerfile
   dockerContext: ./app
+  autoDeploy: false
   disk:
     name: config
     mountPath: /mattermost/config


### PR DESCRIPTION
By setting `autoDeploy: false` in the the `render.yaml`, we can ensure that subsequent merges to the main branch of this repository will not trigger deploys for any instances that have been created and deployed by the Deploy to Render button.

However, merging this PR will trigger a final forced deployment of any instances created and deployed by the Deploy to Render button.

See [the Render docs](https://render.com/docs/deploy-to-render) for more information.

Signed-off-by: zach wick <zach@render.com>