### PR TITLE
Update Alpine Linux and Mattermost Server

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:3.10
+FROM alpine:3.19
 
 # Some ENV variables
 ENV PATH="/mattermost/bin:${PATH}"
-ENV MM_VERSION=5.15.0
+ENV MM_VERSION=9.7.3
 
 # Build argument to set Mattermost edition
 ARG edition=enterprise


### PR DESCRIPTION
Update Alpine Linux to 3.19 and Mattermost Server to 9.7.3 to clear many security issues and bugs. No regression in functionality observed.
